### PR TITLE
Clean develop-flavored cache before gatsby build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ clean:
 	rm -rf _generated
 
 build:
+	@if [ -d .cache/develop-html ]; then gatsby clean; fi
 	gatsby build
 
 serve:


### PR DESCRIPTION
A gatsby develop session records image-processing jobs in .cache without generating the files (they're produced lazily on request). A subsequent gatsby build trusts that cache, skips the sharp jobs, and emits pages referencing images that don't exist in public/static. Detect the develop-flavored cache (.cache/develop-html) and gatsby clean first; build-to-build incremental caching is unaffected.