### PR TITLE
Show search results in a dropdown under the search bar

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useEffect, useRef, useState } from "react"
 import { graphql, Link } from "gatsby"
 import Layout from "../components/layout"
 import Seo from "../components/seo"
@@ -31,6 +31,13 @@ const NoteArticle = ({ node }) => (
   </article>
 )
 
+const NoteRow = ({ node }) => (
+  <Link to={node.fields.slug} className={styles.row}>
+    <span className={styles.rowTitle}>{node.frontmatter.title}</span>
+    <span className={styles.rowDate}>{node.frontmatter.monthYear}</span>
+  </Link>
+)
+
 const CollectionCard = ({ collection, notes }) => (
   <div className={styles.card}>
     <div className={styles.cardHead}>
@@ -43,10 +50,7 @@ const CollectionCard = ({ collection, notes }) => (
     </div>
     <div className={styles.cardBody}>
       {notes.slice(0, CARD_MAX).map(node => (
-        <Link to={node.fields.slug} className={styles.row} key={node.fields.slug}>
-          <span className={styles.rowTitle}>{node.frontmatter.title}</span>
-          <span className={styles.rowDate}>{node.frontmatter.monthYear}</span>
-        </Link>
+        <NoteRow node={node} key={node.fields.slug} />
       ))}
     </div>
     {notes.length > CARD_MAX && (
@@ -70,6 +74,18 @@ export default function Index({ data, location }) {
   const findCollection = slug =>
     collections.find(c => slug.startsWith(`/${c.dir}/`))
   const [searchQ, setSearchQ] = useState("")
+  const [searchOpen, setSearchOpen] = useState(false)
+  const searchRef = useRef(null)
+
+  useEffect(() => {
+    const onMouseDown = event => {
+      if (searchRef.current && !searchRef.current.contains(event.target)) {
+        setSearchOpen(false)
+      }
+    }
+    document.addEventListener("mousedown", onMouseDown)
+    return () => document.removeEventListener("mousedown", onMouseDown)
+  }, [])
 
   const q = searchQ.toLowerCase()
   const matches = nodes.filter(node =>
@@ -89,35 +105,50 @@ export default function Index({ data, location }) {
   return (
     <Layout path={location.pathname}>
       <section className="readable">
-      <div className={styles.search}>
+      <div
+        className={styles.search}
+        ref={searchRef}
+        onKeyDown={event => event.key === "Escape" && setSearchOpen(false)}
+      >
         <i className="fa fa-search"></i>
         <input
           type="text"
+          role="combobox"
           aria-label="search"
+          aria-expanded={searchOpen && !!searchQ}
           placeholder="search notes..."
-          onChange={event => setSearchQ(event.target.value)}
+          value={searchQ}
+          onChange={event => {
+            setSearchQ(event.target.value)
+            setSearchOpen(true)
+          }}
+          onFocus={() => setSearchOpen(true)}
+          onClick={() => setSearchOpen(true)}
         />
+        {searchOpen && searchQ && (
+          <div className={styles.results}>
+            {matches.length ? (
+              matches.map(node => <NoteRow node={node} key={node.id} />)
+            ) : (
+              <div className={styles.noResults}>no matches</div>
+            )}
+          </div>
+        )}
       </div>
-      {searchQ ? (
-        matches.map(node => <NoteArticle node={node} key={node.id} />)
-      ) : (
-        <>
-          <div className={styles.kicker}>writing &amp; projects</div>
-          <div className={styles.writing}>
-            {writing.map(node => <NoteArticle node={node} key={node.id} />)}
-          </div>
-          <div className={styles.kicker}>notes</div>
-          <div className={styles.cards}>
-            {cards.map(({ collection, notes }) => (
-              <CollectionCard
-                collection={collection}
-                notes={notes}
-                key={collection.dir}
-              />
-            ))}
-          </div>
-        </>
-      )}
+      <div className={styles.kicker}>writing &amp; projects</div>
+      <div className={styles.writing}>
+        {writing.map(node => <NoteArticle node={node} key={node.id} />)}
+      </div>
+      <div className={styles.kicker}>notes</div>
+      <div className={styles.cards}>
+        {cards.map(({ collection, notes }) => (
+          <CollectionCard
+            collection={collection}
+            notes={notes}
+            key={collection.dir}
+          />
+        ))}
+      </div>
       </section>
     </Layout>
   )

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -31,9 +31,16 @@ const NoteArticle = ({ node }) => (
   </article>
 )
 
-const NoteRow = ({ node }) => (
+const NoteRow = ({ node, showTags }) => (
   <Link to={node.fields.slug} className={styles.row}>
     <span className={styles.rowTitle}>{node.frontmatter.title}</span>
+    {showTags && node.fields.tags && (
+      <span className={styles.rowTags}>
+        {node.fields.tags.map(tag => (
+          <span className={styles.tag} key={tag}>#{tag}</span>
+        ))}
+      </span>
+    )}
     <span className={styles.rowDate}>{node.frontmatter.monthYear}</span>
   </Link>
 )
@@ -128,7 +135,7 @@ export default function Index({ data, location }) {
         {searchOpen && searchQ && (
           <div className={styles.results}>
             {matches.length ? (
-              matches.map(node => <NoteRow node={node} key={node.id} />)
+              matches.map(node => <NoteRow node={node} showTags key={node.id} />)
             ) : (
               <div className={styles.noResults}>no matches</div>
             )}

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -142,6 +142,20 @@ article {
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+  .rowTags {
+    color: var(--secondary-text-color);
+    flex: none;
+    font-size: 0.82em;
+    max-width: 40%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    .tag {
+      &+ .tag {
+        margin-left: 0.25em;
+      }
+    }
+  }
   .rowDate {
     color: var(--secondary-text-color);
     flex: none;

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -18,6 +18,26 @@
   padding-left: 1.75em;
   width: 100%;
 }
+.results {
+  background: var(--bg-color);
+  border: 1px solid var(--line-color);
+  border-radius: 0.25em;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  left: 0;
+  max-height: 60vh;
+  overflow-y: auto;
+  padding: 0.35em 0.9em 0.45em;
+  position: absolute;
+  right: 0;
+  text-align: left;
+  top: calc(100% + 0.35em);
+  z-index: 10;
+}
+.noResults {
+  color: var(--secondary-text-color);
+  font-size: 0.85em;
+  padding: 0.4em 0;
+}
 article {
   > a {
     border-bottom: 1px solid var(--line-color);


### PR DESCRIPTION
## Summary

- Search results now render in a scrollable dropdown anchored under the search input instead of replacing the homepage; the writing list and collection cards stay visible.
- The dropdown opens on typing/focus/click, closes on Escape or an outside click, and preserves the query so refocusing reopens it. Empty result sets show "no matches".
- Result rows show the note's tags (search matches on tag text, so this shows why a result matched). Tags truncate with an ellipsis on narrow viewports; collection-card rows are unchanged.
- Extracted the duplicated card-row markup into a shared `NoteRow` component and added minimal combobox ARIA (`role="combobox"`, `aria-expanded`) to the input.

## Testing

- Verified in the local dev server: typing shows the dropdown, Escape/outside-click close it, refocus reopens it, result clicks navigate, console clean.
- Checked desktop and mobile (375px) widths; long tag lists truncate cleanly.